### PR TITLE
Fix Debug Blocks affecting double slabs under 1.13+

### DIFF
--- a/src/net/livecar/nuttyworks/npc_destinations/DebugTarget.java
+++ b/src/net/livecar/nuttyworks/npc_destinations/DebugTarget.java
@@ -53,7 +53,12 @@ public class DebugTarget {
             return;
         debugBlocksSent.remove(blockLocation);
         if (((Player) targetSender).isOnline()) {
-            ((Player) targetSender).sendBlockChange(blockLocation, blockLocation.getBlock().getType(), blockLocation.getBlock().getData());
+            try {
+                // 1.13+
+                ((Player) targetSender).sendBlockChange(blockLocation, blockLocation.getBlock().getBlockData());
+            } catch (NoSuchMethodError ex) {
+                ((Player) targetSender).sendBlockChange(blockLocation, blockLocation.getBlock().getType(), blockLocation.getBlock().getData());
+            }
         }
     }
 
@@ -61,7 +66,13 @@ public class DebugTarget {
     public void clearDebugBlocks() {
         for (Location blockLocation : debugBlocksSent) {
             if (((Player) targetSender).isOnline()) {
-                ((Player) targetSender).sendBlockChange(blockLocation, blockLocation.getBlock().getType(), blockLocation.getBlock().getData());
+                try {
+                    // 1.13+
+                    ((Player) targetSender).sendBlockChange(blockLocation, blockLocation.getBlock().getBlockData());
+                } catch (NoSuchMethodError ex) {
+                    // Legacy
+                    ((Player) targetSender).sendBlockChange(blockLocation, blockLocation.getBlock().getType(), blockLocation.getBlock().getData());
+                }
             }
         }
         debugBlocksSent.clear();

--- a/src/net/livecar/nuttyworks/npc_destinations/citizens/Citizens_Processing.java
+++ b/src/net/livecar/nuttyworks/npc_destinations/citizens/Citizens_Processing.java
@@ -510,7 +510,15 @@ public class Citizens_Processing {
                     if (((Player) debugOutput.targetSender).isOnline()) {
                         Player player = ((Player) debugOutput.targetSender);
                         if (player.getWorld().equals(pendDestination.getWorld())) {
-                            player.sendBlockChange(pendDestination, pendDestination.getBlock().getType(), pendDestination.getBlock().getData());
+                            try {
+                                // 1.13+
+                                player.sendBlockChange(pendDestination, pendDestination.getBlock().getBlockData());
+                            } catch (NoSuchMethodError ex) {
+                                // Legacy
+                                player.sendBlockChange(pendDestination, pendDestination.getBlock().getType(), pendDestination.getBlock().getData());
+                            }
+
+
                         }
                     }
                 }
@@ -525,7 +533,13 @@ public class Citizens_Processing {
                 if (((Player) debugOutput.targetSender).isOnline()) {
                     Player player = ((Player) debugOutput.targetSender);
                     if (player.getWorld().equals(trait.getPendingDestinations().get(index).getWorld())) {
-                        player.sendBlockChange(trait.getPendingDestinations().get(index), trait.getPendingDestinations().get(index).getBlock().getType(), trait.getPendingDestinations().get(index).getBlock().getData());
+                        try {
+                            // 1.13+
+                            player.sendBlockChange(trait.getPendingDestinations().get(index), trait.getPendingDestinations().get(index).getBlock().getBlockData());
+                        } catch (NoSuchMethodError ex) {
+                            // Legacy
+                            player.sendBlockChange(trait.getPendingDestinations().get(index), trait.getPendingDestinations().get(index).getBlock().getType(), trait.getPendingDestinations().get(index).getBlock().getData());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Overview
On 1.13+ playerSendBlockChange uses a deprecated method. I believe the old Material data values do not accurately reflect double slabs.

This has been changed to use BlockData instead. As this does not exist under older versions its wrapped with a try/catch and the old method will be used then instead.

# Closes
Closes #21