### PR TITLE
Pin WorldGuard and WorldEdit to their correct snapshots.

### DIFF
--- a/Worldguard_V7_0_0/pom.xml
+++ b/Worldguard_V7_0_0/pom.xml
@@ -36,16 +36,16 @@
         </dependency>
         <!-- WorldGuard -->
         <dependency>
-            <groupId>com.sk89q</groupId>
-            <artifactId>worldguard</artifactId>
-            <version>7.0.0-SNAPSHOT</version>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-core</artifactId>
+            <version>7.0.0-20180830.064510-58</version>
             <scope>provided</scope>
         </dependency>
         <!-- WorldEdit -->
         <dependency>
-            <groupId>com.sk89q</groupId>
-            <artifactId>worldedit</artifactId>
-            <version>7.0.0-SNAPSHOT</version>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-core</artifactId>
+            <version>7.0.0-20180830.064413-44</version>
             <scope>provided</scope>
         </dependency>
 

--- a/Worldguard_V7_0_1/pom.xml
+++ b/Worldguard_V7_0_1/pom.xml
@@ -36,16 +36,16 @@
         </dependency>
         <!-- WorldGuard -->
         <dependency>
-            <groupId>com.sk89q</groupId>
-            <artifactId>worldguard</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-core</artifactId>
+            <version>7.0.0-20181117.063337-9</version>
             <scope>provided</scope>
         </dependency>
         <!-- WorldEdit -->
         <dependency>
-            <groupId>com.sk89q</groupId>
-            <artifactId>worldedit</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-core</artifactId>
+            <version>7.0.0-20181118.055910-28</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
         <module>v1_9_R2</module>
         <module>v1_9_R1</module>
         <module>v1_8_R3</module>
+        <module>Worldguard_V6</module>
+        <module>Worldguard_V7_0_0</module>
+        <module>Worldguard_V7_0_1</module>
     </modules>
 
 


### PR DESCRIPTION
Pins the correct snapshot versions so we don't have to rely on faking it with a local repo.

# Changes:
* Update POM's with correct versions. The latest version also needs to be pinned to the correct version rather than rely on -SNAPSHOT
* Add the two new WorldGuard projects into the parent maven project
